### PR TITLE
bugfix: fix overflow styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -231,16 +231,25 @@ body#page-question-type-ddmatch div[id^=fitem_id_][id*=subanswers_] {
 }
 
 .dragdrop-choice {
-    max-height: 100px;
+    max-height: 180px;
+    overflow: scroll;
+    display: flex;
+    flex-direction: column;
+}
+
+.dragdrop-question {
+    max-height: 250px;
     overflow: scroll;
 }
 
 .dragdrop-question h3,
 .dragdrop-question p {
-    max-height: 100px;
-    overflow: scroll;
     background-color: #f9f8fb;
     padding: 0.5rem 1rem;
+}
+
+.dragdrop-question img {
+    width: 100%;
 }
 
 .dragdrop-choice::-webkit-scrollbar,


### PR DESCRIPTION
This improves a bit of the styling on the question page, namely when you have large images and large text.

- Often `<img>` appear inside the `<p>` tags in the questions/answers because the editor defaults to putting everything inside a P tag. This was then being affected by the max-height to make it scroll. Removed this and only applied this max-height to the answers, not the questions (the questions height is controlled by a `<table>`)
- I increased the max-height a bit. 100px was quite tiny, now with 180px you can comfortably fit 4 max-height answers on a standard monitor.
- Made the images fit the width of the table cell (`width: 100%`)
- Made the contents of the question flex as a column. This aligns it so what you see in the editor is closer what you see in the question.

**Before:**
![image](https://github.com/catalyst/moodle-qtype_ddmatch/assets/17095477/d760deca-5eaf-4c7d-b6ae-6a1171ebaf50)

**After:**
![image](https://github.com/catalyst/moodle-qtype_ddmatch/assets/17095477/c0a183e3-5327-4d80-83be-5d4bd26615d2)

**After (Boost)**:
![image](https://github.com/catalyst/moodle-qtype_ddmatch/assets/17095477/6459bfdb-4f6c-41f9-bb7f-962b80be363e)

