### PR TITLE
Fix styling quirks

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -232,14 +232,14 @@ body#page-question-type-ddmatch div[id^=fitem_id_][id*=subanswers_] {
 
 .dragdrop-choice {
     max-height: 180px;
-    overflow: scroll;
+    overflow-y: auto;
     display: flex;
     flex-direction: column;
 }
 
 .dragdrop-question {
     max-height: 250px;
-    overflow: scroll;
+    overflow-y: auto;
 }
 
 .dragdrop-question h3,


### PR DESCRIPTION
Tiny regression fix for https://github.com/catalyst/moodle-qtype_ddmatch/pull/4

I was testing this in Firefox, but it looks like Chromium based browsers if you set `overflow:scroll` it ALWAYS puts a scrollbar there even if not necessary.

I have changed these to `overflow-y: auto` which fixes this. We don't need overflow on the X anyway, since the content is set to fit the table width so theoretically should never overflow.

Notice now in the after screenshots the unnecessary scrollbars are gone:

|  | Boost | Baz |
|--------|--------|--------|
| Before | ![scroll-boost-before](https://github.com/catalyst/moodle-qtype_ddmatch/assets/17095477/716ae20d-0a0a-4aac-bb22-352ca94a45a2) | ![scroll-baz-before](https://github.com/catalyst/moodle-qtype_ddmatch/assets/17095477/75ff3660-a5a3-41bd-a805-535d0458c7fb) |
| After | ![boost-after](https://github.com/catalyst/moodle-qtype_ddmatch/assets/17095477/b2c50c35-98b4-41f0-8e7b-dd322e80c693) | ![baz-after](https://github.com/catalyst/moodle-qtype_ddmatch/assets/17095477/7dabf8aa-ec2c-4cd0-aaa6-34cdf4e2bb9b) 



